### PR TITLE
Change apiUrl for C4C format to use server root base url + fix DOI urls  (breaking change)

### DIFF
--- a/src/AiTaxonomist.ts
+++ b/src/AiTaxonomist.ts
@@ -129,7 +129,7 @@ export class AiTaxonomist extends LitElement {
             this.isPlantNetBranded = true
         }
         ;(async () => {
-            this.doiUrl = await getGBIFDoi(this.backendFormat)
+            this.doiUrl = await getGBIFDoi(this.apiUrl, this.backendFormat)
         })()
     }
 

--- a/src/utils/identifyRequest.ts
+++ b/src/utils/identifyRequest.ts
@@ -68,7 +68,7 @@ export const getGBIFDoi = async (apiUrl: string, backendFormat: BackendFormat): 
     }
 
     try {
-        const response = await fetch(apiUrl+'/status')
+        const response = await fetch(`${apiUrl}/status`)
         if (response.status === 200) {
             const responseJson: StatusResponse = await response.json()
             return `https://doi.org/${responseJson.gbif_doi}`

--- a/src/utils/identifyRequest.ts
+++ b/src/utils/identifyRequest.ts
@@ -62,13 +62,13 @@ type StatusResponse = {
     gbif_doi: string
     queries: number
 }
-export const getGBIFDoi = async (backendFormat: BackendFormat): Promise<null | string> => {
+export const getGBIFDoi = async (apiUrl: string, backendFormat: BackendFormat): Promise<null | string> => {
     if (backendFormat !== BackendFormat.C4C) {
         return null
     }
 
     try {
-        const response = await fetch('https://c4c.inria.fr/ai-taxonomist/status')
+        const response = await fetch(apiUrl+'/status')
         if (response.status === 200) {
             const responseJson: StatusResponse = await response.json()
             return `https://doi.org/${responseJson.gbif_doi}`

--- a/src/utils/identifyRequestUtils.ts
+++ b/src/utils/identifyRequestUtils.ts
@@ -37,7 +37,7 @@ export const formatC4CRequest = (images: File[], apiUrl: string, apiKey: string 
         form.append('image', images[i])
     }
 
-    const url = new URL(apiUrl)
+    const url = new URL(apiUrl+'/identify')
     url.searchParams.append('lang', getBrowserLang())
     if (apiKey && apiKey.length) {
         url.searchParams.append('api-key', apiKey)

--- a/src/utils/identifyRequestUtils.ts
+++ b/src/utils/identifyRequestUtils.ts
@@ -37,7 +37,7 @@ export const formatC4CRequest = (images: File[], apiUrl: string, apiKey: string 
         form.append('image', images[i])
     }
 
-    const url = new URL(apiUrl+'/identify')
+    const url = new URL(`${apiUrl}/identify`)
     url.searchParams.append('lang', getBrowserLang())
     if (apiKey && apiKey.length) {
         url.searchParams.append('api-key', apiKey)


### PR DESCRIPTION
- change apiUrl for C4C format to be the root url of the API rather than only the identify route. 
- fix url to get the DOI to use the correct url